### PR TITLE
Handle safari standalone mode

### DIFF
--- a/src/dialog/exporter.js
+++ b/src/dialog/exporter.js
@@ -30,7 +30,7 @@ filepicker.extend('exporter', function(){
             options.openTo = fp.services[options.openTo] || options.openTo;
         }
 
-        fp.util.setDefault(options, 'container', fp.browser.isMobile ? 'window' : 'modal');
+        fp.util.setDefault(options, 'container', fp.browser.isMobile() ? 'window' : 'modal');
     };
 
     var getExportHandler = function(onSuccess, onError) {

--- a/src/dialog/exporter.js
+++ b/src/dialog/exporter.js
@@ -30,7 +30,7 @@ filepicker.extend('exporter', function(){
             options.openTo = fp.services[options.openTo] || options.openTo;
         }
 
-        fp.util.setDefault(options, 'container', fp.browser.isMobile() ? 'window' : 'modal');
+        fp.util.setDefault(options, 'container', fp.browser.openInModal() ? 'modal' : 'window');
     };
 
     var getExportHandler = function(onSuccess, onError) {

--- a/src/dialog/picker.js
+++ b/src/dialog/picker.js
@@ -43,7 +43,7 @@ filepicker.extend('picker', function(){
         if (options.openTo) {
             options.openTo = fp.services[options.openTo] || options.openTo;
         }
-        fp.util.setDefault(options, 'container', fp.browser.isMobile ? 'window' : 'modal');
+        fp.util.setDefault(options, 'container', fp.browser.isMobile() ? 'window' : 'modal');
     };
 
     var getPickHandler = function(onSuccess, onError, onProgress) {

--- a/src/dialog/picker.js
+++ b/src/dialog/picker.js
@@ -43,7 +43,7 @@ filepicker.extend('picker', function(){
         if (options.openTo) {
             options.openTo = fp.services[options.openTo] || options.openTo;
         }
-        fp.util.setDefault(options, 'container', fp.browser.isMobile() ? 'window' : 'modal');
+        fp.util.setDefault(options, 'container', fp.browser.openInModal() ? 'modal' : 'window');
     };
 
     var getPickHandler = function(onSuccess, onError, onProgress) {

--- a/src/dialog/window.js
+++ b/src/dialog/window.js
@@ -15,8 +15,7 @@ filepicker.extend('window', function(){
 
     var openWindow = function(container, src, onClose) {
         onClose = onClose || function(){};
-        var isMobile = (fp.browser.isIOS() || fp.browser.isAndroid());
-        if (!container && isMobile){
+        if (!container && fp.browser.isMobile){
             container = 'window';
         } else if (!container) {
             container = 'modal';

--- a/src/dialog/window.js
+++ b/src/dialog/window.js
@@ -15,10 +15,10 @@ filepicker.extend('window', function(){
 
     var openWindow = function(container, src, onClose) {
         onClose = onClose || function(){};
-        if (!container && fp.browser.isMobile()){
-            container = 'window';
-        } else if (!container) {
+        if (!container && fp.browser.openInModal()){
             container = 'modal';
+        } else if (!container) {
+            container = 'window';
         }
 
         if (container === 'window') {

--- a/src/dialog/window.js
+++ b/src/dialog/window.js
@@ -15,7 +15,7 @@ filepicker.extend('window', function(){
 
     var openWindow = function(container, src, onClose) {
         onClose = onClose || function(){};
-        if (!container && fp.browser.isMobile){
+        if (!container && fp.browser.isMobile()){
             container = 'window';
         } else if (!container) {
             container = 'modal';

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -25,6 +25,9 @@ filepicker.extend('browser', function(){
 
     return {
         getLanguage: getLanguage,
+        openInModal: function() {
+            return !(isIOS() || isAndroid()) || !!window.navigator.standalone;
+        },
         isMobile: function() {
             return isIOS() || isAndroid();
         }

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -14,21 +14,6 @@ filepicker.extend('browser', function(){
         return !!navigator.userAgent.match(/Android/i);
     };
 
-    var isIE7 = function() {
-        return !!navigator.userAgent.match(/MSIE 7\.0/i);
-    };
-
-    var isSafari = function() {
-        return (navigator.userAgent.search('Safari') >= 0 &&
-            navigator.userAgent.search('Chrome') < 0);
-    };
-    
-    var isMobileSafari = function() {
-        return !!(navigator.userAgent.match(/(iPod|iPhone|iPad)/) && 
-            navigator.userAgent.match(/AppleWebKit/) && 
-            !navigator.userAgent.match(/CriOS/));
-    };
-
     var getLanguage = function() {
         var language = window.navigator.userLanguage || window.navigator.language;
         if (language === undefined) {
@@ -40,13 +25,9 @@ filepicker.extend('browser', function(){
 
     var isMobile = isIOS() || isAndroid();
     
-
     return {
         isIOS: isIOS,
         isAndroid: isAndroid,
-        isIE7: isIE7,
-        isSafari: isSafari,
-        isMobileSafari: isMobileSafari,
         getLanguage: getLanguage,
         isMobile: isMobile
     };

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -23,12 +23,10 @@ filepicker.extend('browser', function(){
         return language;
     };
 
-    var isMobile = isIOS() || isAndroid();
-    
     return {
-        isIOS: isIOS,
-        isAndroid: isAndroid,
         getLanguage: getLanguage,
-        isMobile: isMobile
+        isMobile: function() {
+            return isIOS() || isAndroid();
+        }
     };
 });

--- a/tests/unit/utils/browser-spec.js
+++ b/tests/unit/utils/browser-spec.js
@@ -26,4 +26,25 @@ describe("The Browser library", function(){
         });
         expect(filepicker.browser.isMobile()).toBe(true);
     });
+
+    it("dont open in modal on mobile devices", function() {
+        navigator.__defineGetter__('userAgent', function(){
+            return "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
+        });
+        expect(filepicker.browser.openInModal()).toBe(false);
+    });
+
+    it("open in modal when safari in standalone mode", function() {
+        navigator.__defineGetter__('userAgent', function(){
+            return "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
+        });
+        navigator.__defineGetter__('standalone', function(){
+            return true;
+        });
+        expect(filepicker.browser.openInModal()).toBe(true);
+    });
+
+    it("open in modal on desktop", function() {
+        expect(filepicker.browser.openInModal()).toBe(true);
+    });
 });

--- a/tests/unit/utils/browser-spec.js
+++ b/tests/unit/utils/browser-spec.js
@@ -1,37 +1,29 @@
 describe("The Browser library", function(){
-    it("correctly identifies that we're not on iOS or Android", function(){
-        expect(filepicker.browser.isIOS()).toBe(false);
-        expect(filepicker.browser.isAndroid()).toBe(false);
+    it("correctly identifies that we're not a mobile device", function(){
+        expect(filepicker.browser.isMobile()).toBe(false);
     });
 
     it("identifies when we are on android", function(){
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1";
         });
-        expect(filepicker.browser.isAndroid()).toBe(true);
-        expect(filepicker.browser.isIOS()).toBe(false);
+        expect(filepicker.browser.isMobile()).toBe(true);
     });
 
     it("identifies when we are on iOS", function(){
-
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A406 Safari/7534.48.3";
         });
-
-        expect(filepicker.browser.isIOS()).toBe(true);
-        expect(filepicker.browser.isAndroid()).toBe(false);
+        expect(filepicker.browser.isMobile()).toBe(true);
 
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3";
         });
-
-        expect(filepicker.browser.isIOS()).toBe(true);
-        expect(filepicker.browser.isAndroid()).toBe(false);
+        expect(filepicker.browser.isMobile()).toBe(true);
 
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
         });
-        expect(filepicker.browser.isIOS()).toBe(true);
-        expect(filepicker.browser.isAndroid()).toBe(false);
+        expect(filepicker.browser.isMobile()).toBe(true);
     });
 });

--- a/tests/unit/utils/browser-spec.js
+++ b/tests/unit/utils/browser-spec.js
@@ -27,14 +27,14 @@ describe("The Browser library", function(){
         expect(filepicker.browser.isMobile()).toBe(true);
     });
 
-    it("dont open in modal on mobile devices", function() {
+    it("does not open in modal on mobile devices", function() {
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
         });
         expect(filepicker.browser.openInModal()).toBe(false);
     });
 
-    it("open in modal when safari in standalone mode", function() {
+    it("opens in modal when safari in standalone mode", function() {
         navigator.__defineGetter__('userAgent', function(){
             return "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
         });
@@ -44,7 +44,7 @@ describe("The Browser library", function(){
         expect(filepicker.browser.openInModal()).toBe(true);
     });
 
-    it("open in modal on desktop", function() {
+    it("opens in modal on desktop", function() {
         expect(filepicker.browser.openInModal()).toBe(true);
     });
 });


### PR DESCRIPTION
This patch force the modal mode when safari is in standalone mode. See #10.

I included some cleanup to remove unused methods. I can easily remove theses commits.

