### PR TITLE
Responsive images lookup can be triggered at any time

### DIFF
--- a/src/library/lib.js
+++ b/src/library/lib.js
@@ -742,6 +742,10 @@ filepicker.extend(function(){
         return fp.responsiveImages.setResponsiveOptions(options);
     };
 
+    var responsive = function(){
+        fp.responsiveImages.update.apply(null, arguments);
+    };
+
     return {
         setKey: setKey,
         setResponsiveOptions: setResponsiveOptions,
@@ -764,6 +768,7 @@ filepicker.extend(function(){
         constructWidget: constructWidget,
         makeDropPane: makeDropPane,
         FilepickerException: FilepickerException,
+        responsive: responsive,
         version: VERSION
     };
 }, true);

--- a/src/widgets/responsive_images.js
+++ b/src/widgets/responsive_images.js
@@ -59,7 +59,7 @@ filepicker.extend('responsiveImages', function(){
             if (element.nodeName === 'IMG') {
                 construct(element);
             } else {
-                throw new Error('Passed object is not an image');
+                throw new fp.FilepickerException('Passed object is not an image');
             }
         } else {
             constructAll(true);

--- a/src/widgets/responsive_images.js
+++ b/src/widgets/responsive_images.js
@@ -62,10 +62,7 @@ filepicker.extend('responsiveImages', function(){
                 throw new Error('Passed object is not an image');
             }
         } else {
-            var responsiveImages = document.querySelectorAll('img[data-fp-src]');
-            for (var i = 0; i < responsiveImages.length; i++) {
-                construct(responsiveImages[i]);
-            }
+            constructAll(true);
         }
     }
 
@@ -76,14 +73,14 @@ filepicker.extend('responsiveImages', function(){
     *   @method constructAll
     */
 
-    function constructAll(){
+    function constructAll(forceConstruct){
         var responsiveImages = document.querySelectorAll('img[data-fp-src]'),
             element,
             i;
 
         for (i=0; i< responsiveImages.length; i++) {
             element = responsiveImages[i];
-            if (shouldConstruct(element)) {
+            if (shouldConstruct(element) || forceConstruct === true) {
                 construct(element);
             }
         }

--- a/src/widgets/responsive_images.js
+++ b/src/widgets/responsive_images.js
@@ -2,7 +2,7 @@
 // responsive_images.js
 
 /*
-    responsive image widget 
+    responsive image widget
     TODO: security option
 */
 
@@ -18,6 +18,7 @@ filepicker.extend('responsiveImages', function(){
     return {
         activate: activate,
         deactivate: deactivate,
+        update: update,
         setResponsiveOptions: setResponsiveOptions,
         getResponsiveOptions: getResponsiveOptions,
         getElementDims: getElementDims,
@@ -52,8 +53,24 @@ filepicker.extend('responsiveImages', function(){
         removeWindowResizeEvent(reloadWithDebounce);
     }
 
+    function update(element){
+        if (element !== undefined) {
+            // If <img> given as a parameter then just process it directly.
+            if (element.nodeName === 'IMG') {
+                construct(element);
+            } else {
+                throw new Error('Passed object is not an image');
+            }
+        } else {
+            var responsiveImages = document.querySelectorAll('img[data-fp-src]');
+            for (var i = 0; i < responsiveImages.length; i++) {
+                construct(responsiveImages[i]);
+            }
+        }
+    }
+
     /**
-    *   Search for all images with data-fp-src attribute 
+    *   Search for all images with data-fp-src attribute
     *   and rebuild its source url if needed
     *
     *   @method constructAll
@@ -74,7 +91,7 @@ filepicker.extend('responsiveImages', function(){
 
 
     /**
-    *   Depend on responsive images options and current image size return true 
+    *   Depend on responsive images options and current image size return true
     *   if image url should be constructed or false if not
     *
     *   @method shouldConstruct
@@ -107,7 +124,7 @@ filepicker.extend('responsiveImages', function(){
 
         var shouldBeEnlarged = getCurrentResizeParams(imageSrc).width < getElementDims(image).width;
 
-        if ((shouldBeEnlarged && changeOnResize === 'up') || 
+        if ((shouldBeEnlarged && changeOnResize === 'up') ||
             (!shouldBeEnlarged && changeOnResize === 'down')) {
             return true;
         }
@@ -136,7 +153,7 @@ filepicker.extend('responsiveImages', function(){
         /*
            Hack for images with an alt and no src tag.
            Example: <img data-src="img.jpg" alt="An Image"/>
-           Since the image has no parsable src yet, the browser actually 
+           Since the image has no parsable src yet, the browser actually
            reports the width of the alt construct.
            We return the parent nodes sizes instead.
         */
@@ -258,7 +275,7 @@ filepicker.extend('responsiveImages', function(){
     *
     *   @method getCurrentResizeParams
     *   @param {String} url - Image url
-    *   @returns {Object} 
+    *   @returns {Object}
     *       width {Number}
     *       height {Number}
     */
@@ -269,14 +286,14 @@ filepicker.extend('responsiveImages', function(){
 
 
     /**
-    *   Construct responsive image = set proper image source 
+    *   Construct responsive image = set proper image source
     *
     *   @method construct
     *   @param {DOMElement} elem - Image element
     */
 
     function construct(elem){
-        var url = getFpSrcAttr(elem),
+        var url = getFpSrcAttr(elem) || getSrcAttr(elem),
             apikey = getFpKeyAttr(elem) || fp.apikey,
             responsiveOptions = getResponsiveOptions();
 
@@ -292,13 +309,13 @@ filepicker.extend('responsiveImages', function(){
 
 
     /**
-    *   Construct elemenet params based on 
+    *   Construct elemenet params based on
     *   element atributes and responsive options
     *
     *   @method construct
     *   @param {DOMElement} elem - Image element
     *   @param {Object} responsiveOptions
-    *   @returns {Object} params 
+    *   @returns {Object} params
     */
 
     function constructParams(elem, responsiveOptions){
@@ -360,7 +377,7 @@ filepicker.extend('responsiveImages', function(){
     *
     *   @method addWindowResizeEvent
     */
-  
+
     function addWindowResizeEvent(onWindowResized) {
         if (window.addEventListener) {
             window.addEventListener('resize', onWindowResized, false);
@@ -374,7 +391,7 @@ filepicker.extend('responsiveImages', function(){
     *
     *   @method removeWindowResizeEvent
     */
-    
+
     function removeWindowResizeEvent(onWindowResized) {
         if (window.removeEventListener) {
             window.removeEventListener('resize', onWindowResized, false);
@@ -417,7 +434,7 @@ filepicker.extend('responsiveImages', function(){
         }
 
         fp.responsiveOptions = options;
-        
+
     }
 
 

--- a/tests/unit/widgets/responsive_images-spec.js
+++ b/tests/unit/widgets/responsive_images-spec.js
@@ -377,9 +377,12 @@ describe('The responsive images module', function(){
             document.createElement('div'),
             '<img src="nothing.png">'
         ].forEach(function (item) {
-            expect(function () {
+            try {
                 filepicker.responsive(item);
-            }).toThrow(new Error('Passed object is not an image'));
+                throw 'make sure code throws';
+            } catch (err) {
+                expect(err.text).toBe('Passed object is not an image');
+            }
         })
     });
 


### PR DESCRIPTION
Fixes https://github.com/filepicker/filepicker-js/issues/14
You can do two things with this API:

1) By calling 
```js
filepicker.responsive();
``` 
at any moment full lookup for images with `data-fp-src` will be performed.

2) By passing as a parameter to this method DOM image element, 
```js
var img = document.querySelector('.my-img');
filepicker.responsive(img);
```
only this one image will be transformed to responsive.

Tested usage with masonry.js and unveil.js. Here are the samples: https://github.com/filepicker/filepicker-samples/tree/master/responsive_images