### PR TITLE
Replace cdn urls for preview widget

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -88,7 +88,7 @@ filepicker.extend('util', function(){
     */
     var getFPUrl = function(url){
         if (typeof url === 'string') {
-            var matched = url.match(/(cdn\.filestackcontent\.com|cdn\.filepicker\.io)[\S]*\/([\S]{20,})/);
+            var matched = url.match(/(cdn.filestackcontent.com|cdn.filepicker.io)[\S]*\/([\S]{20,})/);
             if (matched && matched.length > 1) {
                 return fp.urls.BASE + '/api/file/' + matched[1];
             }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -88,7 +88,7 @@ filepicker.extend('util', function(){
     */
     var getFPUrl = function(url){
         if (typeof url === 'string') {
-            var matched = url.match(/(cdn.filestackcontent.com|cdn.filepicker.io)[\S]*\/([\S]{20,})/);
+            var matched = url.match(/(?:cdn.filestackcontent.com|cdn.filepicker.io)[\S]*\/([\S]{20,})/);
             if (matched && matched.length > 1) {
                 return fp.urls.BASE + '/api/file/' + matched[1];
             }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -88,7 +88,7 @@ filepicker.extend('util', function(){
     */
     var getFPUrl = function(url){
         if (typeof url === 'string') {
-            var matched = url.match(/cdn.filestackcontent.[\S]*\/([\S]{20,})/);
+            var matched = url.match(/(cdn\.filestackcontent\.com|cdn\.filepicker\.io)[\S]*\/([\S]{20,})/);
             if (matched && matched.length > 1) {
                 return fp.urls.BASE + '/api/file/' + matched[1];
             }

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -536,6 +536,7 @@ filepicker.extend('widgets', function(){
         if (!url || !fp.util.isFPUrl(url)) {
             return true;
         } else {
+            url = fp.util.getFPUrl(url);
             url = url.replace('api/file/', 'api/preview/');
         }
 

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -532,7 +532,7 @@ filepicker.extend('widgets', function(){
     var constructPreview = function(domElement) {
         var url = domElement.getAttribute('data-fp-url'),
             css = domElement.getAttribute('data-fp-custom-css');
-        url = fp.util.getFPUrl(url);
+        var url = fp.util.getFPUrl(url);
         if (!url || !fp.util.isFPUrl(url)) {
             return true;
         } else {

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -532,11 +532,10 @@ filepicker.extend('widgets', function(){
     var constructPreview = function(domElement) {
         var url = domElement.getAttribute('data-fp-url'),
             css = domElement.getAttribute('data-fp-custom-css');
-
+	url = fp.util.getFPUrl(url);
         if (!url || !fp.util.isFPUrl(url)) {
             return true;
         } else {
-            url = fp.util.getFPUrl(url);
             url = url.replace('api/file/', 'api/preview/');
         }
 

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -532,7 +532,7 @@ filepicker.extend('widgets', function(){
     var constructPreview = function(domElement) {
         var url = domElement.getAttribute('data-fp-url'),
             css = domElement.getAttribute('data-fp-custom-css');
-	url = fp.util.getFPUrl(url);
+        url = fp.util.getFPUrl(url);
         if (!url || !fp.util.isFPUrl(url)) {
             return true;
         } else {

--- a/tests/unit/utils/util-spec.js
+++ b/tests/unit/utils/util-spec.js
@@ -63,10 +63,6 @@ describe("The utils library", function(){
                 output: 'http://www.filestackapi.com/api/file/zEJ90dDpS2iPriLsKY9Y',
             },
             {
-                input: 'cdn.filestackcontent.dev:8080/no7gIBeQRhWq7Ce9FRrw',
-                output: filepicker.urls.BASE+'/api/file/no7gIBeQRhWq7Ce9FRrw'
-            },
-            {
                 input: 'https://api.filestackapi.com/api/file/zEJ90dDpS2iPriLsKY9Y',
                 output: 'https://api.filestackapi.com/api/file/zEJ90dDpS2iPriLsKY9Y'
             },


### PR DESCRIPTION
This PR replaces cdn links for preview - this is needed because of firefox problem with javascript workers which don't support crossdomain requests.