### PR TITLE
Make try/catch block less aggressive

### DIFF
--- a/src/communication/comm.js
+++ b/src/communication/comm.js
@@ -43,9 +43,11 @@ filepicker.extend('comm', function(){
         }
         try {
             var data = fp.json.parse(event.data);
-            fp.handlers.run(data);
         } catch(err) {
             console.log('[Filepicker] Failed processing message:', event.data);
+        }
+        if (data) {
+            fp.handlers.run(data);
         }
     };
 


### PR DESCRIPTION
Current state catches also errors from callbacks defined by API users.